### PR TITLE
feat(ui): display with emoji indicators for tense and politeness

### DIFF
--- a/script.js
+++ b/script.js
@@ -84,11 +84,38 @@ function generateQuestion() {
     currentAnswer = wordData[wordIndex][key[formIndex]];
 
     document.getElementById("verb-text").innerText = wordData[wordIndex].word;
-    document.getElementById("conjugation-inquery-text").innerText = conjugationForms[formIndex];
+
+    const tenseEmoji = getTenseEmoji(formIndex);
+    const politenessEmoji = getPolitenessEmoji(formIndex);
+    const conjugationContainer = document.getElementById("conjugation-inquery-text");
+    conjugationContainer.innerHTML = `
+        <span>${conjugationForms[formIndex]}</span>
+        <div class="emoji-indicators">
+            <span class="tense-emoji">${tenseEmoji}</span>
+            <span class="politeness-emoji">${politenessEmoji}</span>
+        </div>
+    `;
+
     document.getElementById("translation").innerText = wordData[wordIndex].tr;
     if (translationAfter) {
         document.getElementById("translation").classList.add("display-none")
     }
+}
+
+function getTenseEmoji(formIndex) {
+    if (formIndex >= 0 && formIndex <= 2) return '⚡'; // Present
+    if (formIndex >= 3 && formIndex <= 5) return '⏪'; // Past
+    if (formIndex >= 6 && formIndex <= 8) return '🔮'; // Future
+    if (formIndex >= 9 && formIndex <= 11) return '❗'; // Imperative
+    return '⚡';
+}
+
+function getPolitenessEmoji(formIndex) {
+    const politenessIndex = formIndex % 3;
+    if (politenessIndex === 0) return '😎'; // Plain (반말)
+    if (politenessIndex === 1) return '😊'; // Polite (해요체)
+    if (politenessIndex === 2) return '🎩'; // Very formal (습니다체)
+    return '😎';
 }
 
 function updateStatus(message, color) {

--- a/styles.css
+++ b/styles.css
@@ -155,6 +155,22 @@ span.rt {
 	font-size: 1.3rem;
 	margin-top: 0.8rem;
 	margin-bottom: 0.5rem;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 0.3rem;
+}
+
+.emoji-indicators {
+	display: flex;
+	gap: 0.5rem;
+	align-items: center;
+}
+
+.tense-emoji, .politeness-emoji {
+	font-size: 1rem;
+	flex-shrink: 0;
 }
 
 #status-container {


### PR DESCRIPTION
Add emoji indicators for tense and politeness levels

Add visual emoji indicators to help users quickly identify tense and politeness levels, inspired by the original Japanese conjugation app this Korean version is based on.

**Location:** script.js + styles.css

**Changes:**
- Add `getTenseEmoji()` and `getPolitenessEmoji()` functions
- Modify `generateQuestion()` to display emojis below conjugation text  
- `⚡⏪🔮❗` for tenses (present/past/future/imperative)
- `😎😊🎩` for politeness (casual/polite/formal)

**Note:** Emoji choices are suggestions and can be changed if you prefer different ones.

Fixes #3